### PR TITLE
fix: avoid throwing errors

### DIFF
--- a/src/commands/prefix/send-role-select.ts
+++ b/src/commands/prefix/send-role-select.ts
@@ -29,9 +29,10 @@ const command: PrefixCommand = {
       process.env.FEEDBACK_CHANNEL_ID,
     );
     if (!feedbackChannel) {
-      throw new Error(
-        "Please set the correct `FEEDBACK_CHANNEL_ID` in `.env`.",
+      console.error(
+        `\`FEEDBACK_CHANNEL_ID\` ${process.env.FEEDBACK_CHANNEL_ID} not exists in ${message.guild.name} `,
       );
+      return;
     }
     await message.channel.send({
       content: `

--- a/src/handlers/prefixCommands.handler.ts
+++ b/src/handlers/prefixCommands.handler.ts
@@ -18,7 +18,8 @@ export const loadPrefixCommands = async (client: Client): Promise<void> => {
   console.log(`Loaded (${commands.length}) prefix commands`);
   commands.forEach(({ data }) => {
     if (client.prefixCommands.has(data.name)) {
-      throw Error(`Prefix command "${data.name}" already exists!`);
+      console.error(`Prefix command "${data.name}" already exists!`);
+      return;
     }
     client.prefixCommands.set(data.name, data);
   });


### PR DESCRIPTION
Throwing error will cause bot logging out, this is not acceptable in production.