### PR TITLE
build: production

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,15 @@ on:
     branches: [main]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+
   lint-check:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 .idea/
+dist/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "npx eslint .",
     "lint-fix": "npx eslint . --fix",
     "format": "npx prettier . --check",
-    "format-fix": "npx prettier . --write"
+    "format-fix": "npx prettier . --write",
+    "build": "npx tsc",
+    "prod": "node --experimental-specifier-resolution=node dist/index"
   },
   "keywords": [
     "discord",

--- a/src/utils/filesImport.ts
+++ b/src/utils/filesImport.ts
@@ -13,8 +13,12 @@ interface IReturn<T> {
 export const importFiles = async <T>({
   path,
 }: IImportFiles): Promise<IReturn<T>[]> => {
-  const entries = await readdirp.promise(`./src/${path}`, {
-    fileFilter: ["*.ts", "!*.handler.ts"],
+  const inProduction = process.env["NODE_ENV"] === "production";
+  const dirRoot = inProduction ? "dist" : "src";
+  const fileFilter = inProduction ? "*.js" : "*.ts";
+
+  const entries = await readdirp.promise(`./${dirRoot}/${path}`, {
+    fileFilter: [fileFilter],
   });
   const files = entries.map(async (entry) =>
     import(pathToFileURL(entry.fullPath).href).then((file: { default: T }) => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,17 +15,22 @@
 
     // Modules
     "allowArbitraryExtensions": true,
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "node",
 
     // Emit
     "preserveConstEnums": true,
     "sourceMap": true,
+    "outDir": "dist",
 
     // Interop Constraints
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+
+    // Completeness
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts", "env.d.ts"],
+  "exclude": ["node_modules"],
   "ts-node": {
     "esm": true,
     "experimentalSpecifierResolution": "node",


### PR DESCRIPTION
Prior to this PR, I always run ts directly even in production.

Start from this PR, we can use `npm run build` and `npm run prod` to compile and run js code.